### PR TITLE
plugins update versions

### DIFF
--- a/jenkins-config.yaml
+++ b/jenkins-config.yaml
@@ -182,15 +182,15 @@ controller:
   installPlugins:
     - kubernetes:1.29.2
     - kubernetes-cli:1.10.0
-    - workflow-job:2.40
+    - workflow-job:2.42
     - workflow-aggregator:2.6
     - docker-workflow:1.26
     - job-dsl:1.77
-    - git:4.7.1
-    - configuration-as-code:1.51
+    - git:4.8.3
+    - configuration-as-code:1.54
     - command-launcher:1.5
     - pipeline-utility-steps:2.7.0
-    - blueocean:1.24.5
+    - blueocean:1.25.1
 
 
   # List of plugins to install in addition to those listed in controller.installPlugins


### PR DESCRIPTION
Atualizaçõs de plugins do jenkins

nova versões:
    - workflow-job:2.42 
    - git:4.8.3
    - configuration-as-code:1.54
    - blueocean:1.25.1